### PR TITLE
Run unit tests on every PR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,7 +4,7 @@ on:
       - '*'
 
 env:
-  GO_VERSION: '^1.17'
+  GO_VERSION: '^1.21'
 
 jobs:
   release:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,7 +4,7 @@ on:
     branches: [main]
 
 env:
-  GO_VERSION: '^1.17'
+  GO_VERSION: '^1.21'
 
 jobs:
   check:

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -5,7 +5,7 @@ set -eu
 complexity_check() {
     echo "*** Complexity check"
     go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
-    gocyclo -avg -total -over 15 .
+    gocyclo -avg -over 15 .
 }
 
 format_check() {

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -2,51 +2,51 @@
 
 set -eu
 
-mecha_complexity_check() {
+complexity_check() {
     echo "*** Complexity check"
     go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
     gocyclo -avg -total -over 15 .
 }
 
-mecha_format_check() {
+format_check() {
     echo "*** Format check"
     gofmt -s -e -d -l . | tee /tmp/gofmt.output && [ $(cat /tmp/gofmt.output | wc -l) -eq 0 ]
 }
 
-mecha_inefficiencies_check() {
+inefficiencies_check() {
     echo "*** Inefficiencies check"
     go install github.com/gordonklaus/ineffassign@latest
     go mod tidy
     ineffassign ./...
 }
 
-mecha_smells_check() {
+smells_check() {
     echo "*** Smells check"
     go mod tidy
     go vet ./...
 }
 
-mecha_spelling_check() {
+spelling_check() {
     echo "*** Spelling check"
     go install github.com/client9/misspell/cmd/misspell@latest
     misspell -error .
 }
 
-mecha_static_check() {
+static_check() {
     echo "*** Static check"
     go install honnef.co/go/tools/cmd/staticcheck@latest
     go mod download
     staticcheck ./...
 }
 
-mecha_style_check() {
+style_check() {
     echo "*** Style check"
     go install golang.org/x/lint/golint@latest
     golint ./...
 }
 
 check_functions() {
-    declare -F | awk '{print $3}' | grep -E "^mecha_" | grep -E "_check$" | sed -e 's/_check$//'
+    declare -F | awk '{print $3}' | grep -E "_check$" | sed -e 's/_check$//'
 }
 
 try() {

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -2,6 +2,11 @@
 
 set -eu
 
+tests_check() {
+    echo "*** Run unit tests"
+    go test -v ./... -race -covermode=atomic
+}
+
 complexity_check() {
     echo "*** Complexity check"
     go install github.com/fzipp/gocyclo/cmd/gocyclo@latest


### PR DESCRIPTION
This makes the `check.sh` script to also run unit tests. As this should happen on every PR, we're ensuring not getting regression bugs.

This change also includes some more changes:
* Gocyclo's `-total` option was failing, maybe it never worked well.
* Go version was upgraded to 1.21
* The `check.sh` script is now not mentioning mecha, so this can be
  used in other projects without confusion.